### PR TITLE
Add ZipCode Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,43 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="ZipCode info from https://api.zippopotam.us/")
+@Slf4j
 @RestController
+@RequestMapping("/api/zipcode")
 public class ZipCodeController {
-    
+     
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ZipCodeQueryService zipCodeQueryService;
+
+    @Operation(summary="Get info about a zipcode", description ="JSON return format documented here: https://api.zippopotam.us/")
+    @GetMapping("/get")
+
+    public ResponseEntity<String> getZipCode(
+        @Parameter(name="zipcode", example="93117") @RequestParam String zipcode
+    ) throws JsonProcessingException {
+        log.info("getZipCode: zipcode={}", zipcode);
+        String result = zipCodeQueryService.getJSON(zipcode);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -16,7 +16,7 @@ public class ZipCodeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
        return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -1,16 +1,28 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+@Slf4j
 @Service
 public class ZipCodeQueryService {
+
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -22,8 +34,16 @@ public class ZipCodeQueryService {
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
         log.info("zipcode={}", zipcode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, String> uriVariables = Map.of("zipcode", zipcode);
-        return "";
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
 import org.springframework.stereotype.Service;
@@ -19,6 +21,9 @@ public class ZipCodeQueryService {
     public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
-       return "";
+        log.info("zipcode={}", zipcode);
+
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
+        return "";
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = ZipCodeController.class)
+public class ZipCodeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  ZipCodeQueryService mockZipCodeQueryService;
+
+
+  @Test
+  public void test_getZipCodes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String zipcode = "93117";
+    when(mockZipCodeQueryService.getJSON(eq(zipcode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/zipcode/get?zipcode=%s", zipcode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(ZipCodeQueryService.class)
+public class ZipCodeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ZipCodeQueryService zipCodeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String zipcode = "93117";
+        String expectedURL = ZipCodeQueryService.ENDPOINT.replace("{zipcode}", zipcode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = zipCodeQueryService.getJSON(zipcode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information about the location of a particular zipcode. - controller

Personal deployed at this link:
http://team01-jiaqiguan2003-dev.dokku-06.cs.ucsb.edu/swagger-ui/index.html#l 
<img width="1426" alt="Screen Shot 2024-01-24 at 11 30 54 PM" src="https://github.com/ucsb-cs156-w24/team01-w24-5pm-2/assets/124765197/4709181d-b017-4acc-9605-c294b6545550">

Closes #17 