### PR TITLE
Add Location Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name="Location info from nominatim.openstreetmap.org")
+@Tag(name="Location info from nominatim.org")
 @Slf4j
 @RestController
 @RequestMapping("/api/locations")

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -2,7 +2,39 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Location info from nominatim.openstreetmap.org")
+@Slf4j
 @RestController
+@RequestMapping("/api/locations")
 public class LocationController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    LocationQueryService locationQueryService; 
+
+    @Operation(summary = "Get list of locations that match a given location name", description = "Uses API documented here: https://nominatim.org/release-docs/develop/api/Search/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getLocations(
+        @Parameter(name="location", description="name to search", example="Isla Vista") @RequestParam String location
+    ) throws JsonProcessingException {
+        log.info("getLocation: location={}", location);
+        String result = locationQueryService.getJSON(location);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -16,7 +16,7 @@ public class LocationQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search?q={location}&format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -1,14 +1,28 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
 @Service
 public class LocationQueryService {
+
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -19,6 +33,17 @@ public class LocationQueryService {
     public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search?q={location}&format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
-        return "";
+        log.info("location={}", location);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("location", location);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = LocationController.class)
+public class LocationControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    LocationQueryService mockLocationQueryService;
+
+
+    @Test
+    public void test_getLocations() throws Exception {
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String location = "Oakland";
+        when(mockLocationQueryService.getJSON(eq(location))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/locations/get?location=%s",location);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryServiceTests.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(LocationQueryService.class)
+public class LocationQueryServiceTests {
+    
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private LocationQueryService locationQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String location = "Oakland";
+        String expectedURL = locationQueryService.ENDPOINT.replace("{location}", location);
+        
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+    
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = locationQueryService.getJSON(location);
+        assertEquals(fakeJsonResult, actualResult);
+
+        
+    }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/location/get` that can be used to get a list of locations that match a given location name.

dev deployment: http://team01-aqiu28517-dev.dokku-06.cs.ucsb.edu/

Closes #9 